### PR TITLE
Fixes ruby deprecation notices, which clutter cucumber output

### DIFF
--- a/lib/best_in_place/display_methods.rb
+++ b/lib/best_in_place/display_methods.rb
@@ -30,15 +30,15 @@ module BestInPlace
     end
 
     def add_model_method(klass, attr, display_as)
-      model_attributes(klass)[attr.to_s] = Renderer.new method: display_as.to_sym, type: :model
+      model_attributes(klass)[attr.to_s] = Renderer.new({ method: display_as.to_sym, type: :model })
     end
 
     def add_helper_method(klass, attr, helper_method, helper_options = nil)
-      model_attributes(klass)[attr.to_s] = Renderer.new method: helper_method.to_sym, type: :helper, attr: attr, helper_options: helper_options
+      model_attributes(klass)[attr.to_s] = Renderer.new({ method: helper_method.to_sym, type: :helper, attr: attr, helper_options: helper_options })
     end
 
     def add_helper_proc(klass, attr, helper_proc)
-      model_attributes(klass)[attr.to_s] = Renderer.new type: :proc, attr: attr, proc: helper_proc
+      model_attributes(klass)[attr.to_s] = Renderer.new({ type: :proc, attr: attr, proc: helper_proc })
     end
 
     def model_attributes(klass)


### PR DESCRIPTION
Ruby 3 is deprecating interchangeable kwargs / hash, so this clarifies that it's passing a hash.

I've tested the change locally - when this is merged, we can load from this fork into our Gemfile.